### PR TITLE
Update api.py for python 3 compatibilty

### DIFF
--- a/aqi.py
+++ b/aqi.py
@@ -43,7 +43,7 @@ def construct_command(cmd, data=[]):
 
     if DEBUG:
         dump(ret, '> ')
-    return ret
+    return ret.encode()
 
 def process_data(d):
     r = struct.unpack('<HHxxBB', d[2:])


### PR DESCRIPTION
As written in the pyserial docs, the write function must get a bytes input

 https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.write